### PR TITLE
Placeholder for new 11249 postalcode record

### DIFF
--- a/data/179/673/031/3/1796730313.geojson
+++ b/data/179/673/031/3/1796730313.geojson
@@ -1,0 +1,59 @@
+{
+  "id": 1796730313,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:bbox":"0.0,0.0,0.0,0.0",
+    "geom:latitude":0.0,
+    "geom:longitude":0.0,
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"whosonfirst",
+    "wof:belongsto":[
+        421205765,
+        102191575,
+        85633793,
+        102081863,
+        85977539,
+        907215781,
+        85857853,
+        85688543
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{},
+    "wof:country":"US",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:hierarchy":[
+        {
+            "borough_id":421205765,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081863,
+            "locality_id":85977539,
+            "macrohood_id":907215781,
+            "neighbourhood_id":85857853,
+            "postalcode_id":1796730313,
+            "region_id":85688543
+        }
+    ],
+    "wof:id":1796730313,
+    "wof:lastmodified":1669661602,
+    "wof:name":"11249",
+    "wof:parent_id":85857853,
+    "wof:placetype":"postalcode",
+    "wof:repo":"whosonfirst-data-postalcode-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    0.0,
+    0.0,
+    0.0,
+    0.0
+],
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+}


### PR DESCRIPTION
Placeholder for https://github.com/whosonfirst-data/whosonfirst-data/issues/2016

This PR adds a new record for the postalcode of 11249 in NYC.